### PR TITLE
Fix typo in login page title

### DIFF
--- a/client/src/pages/login/Login.tsx
+++ b/client/src/pages/login/Login.tsx
@@ -45,7 +45,7 @@ const LoginPage: React.FC = () => {
           }}
         >
           <Typography component="h1" variant="h5">
-            Traffiking Escape
+            Trafficking Escape
           </Typography>
 
           <Box


### PR DESCRIPTION
## Summary
- correct spelling on the login page heading

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68418b8c9bac8332b4a1ab94e00cc710