### PR TITLE
Streamline admin panel and remove session backend

### DIFF
--- a/client/src/pages/admin/Admin.tsx
+++ b/client/src/pages/admin/Admin.tsx
@@ -1,9 +1,5 @@
-import React, { useCallback, useEffect, useState } from 'react';
-import styles from './admin.module.css'
-interface Session {
-  id: number;
-  name: string;
-}
+import React, { useEffect, useState } from 'react';
+import styles from './admin.module.css';
 
 interface CreatedUser {
   username: string;
@@ -11,34 +7,29 @@ interface CreatedUser {
   expirationDate: string;
 }
 
+const STORAGE_KEY = 'createdUsers';
+
 const Admin: React.FC = () => {
-  const [sessions, setSessions] = useState<Session[]>([]);
-  const [sessionName, setSessionName] = useState('');
   const [validityMinutes, setValidityMinutes] = useState(60);
   const [createdUsers, setCreatedUsers] = useState<CreatedUser[]>([]);
   const [copiedKey, setCopiedKey] = useState<string | null>(null);
 
   const token = localStorage.getItem('authToken');
 
-  const fetchSessions = useCallback(async () => {
-    try {
-      const res = await fetch(`${import.meta.env.VITE_BACKEND}/api/v1/sessions`, {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      });
-      if (res.ok) {
-        const data = await res.json();
-        setSessions(data);
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      try {
+        setCreatedUsers(JSON.parse(stored));
+      } catch (err) {
+        console.error('Failed to parse stored users', err);
       }
-    } catch (err) {
-      console.error('Failed to load sessions', err);
     }
-  }, [token]);
+  }, []);
 
   useEffect(() => {
-    fetchSessions();
-  }, [fetchSessions]);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(createdUsers));
+  }, [createdUsers]);
 
   const handleCopy = async (value: string, key: string) => {
     try {
@@ -47,26 +38,6 @@ const Admin: React.FC = () => {
       setTimeout(() => setCopiedKey(null), 1500);
     } catch (err) {
       console.error('Copy failed', err);
-    }
-  };
-
-
-  const createSession = async () => {
-    try {
-      const res = await fetch(`${import.meta.env.VITE_BACKEND}/api/v1/sessions`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`,
-        },
-        body: JSON.stringify({ name: sessionName }),
-      });
-      if (res.ok) {
-        setSessionName('');
-        fetchSessions();
-      }
-    } catch (err) {
-      console.error('Failed to create session', err);
     }
   };
 
@@ -90,49 +61,9 @@ const Admin: React.FC = () => {
     }
   };
 
-
-
   return (
     <div className={styles.admin}>
       <h2>Admin Panel</h2>
-
-      <section className={styles.section}>
-        <h3>Sessions</h3>
-        <div className={styles.formRow}>
-          <input
-            type="text"
-            value={sessionName}
-            placeholder="Session name"
-            onChange={(e) => setSessionName(e.target.value)}
-          />
-          <button onClick={createSession}>Create Session</button>
-        </div>
-        <table className={styles.table}>
-          <thead>
-          <tr>
-            <th>ID</th>
-            <th>Name</th>
-          </tr>
-          </thead>
-          <tbody>
-          {sessions.map((s) => (
-            <tr key={s.id}>
-              <td>
-                {s.id}
-                <button
-                  className={styles.copyButton}
-                  onClick={() => handleCopy(String(s.id), `session-${s.id}`)}
-                >
-                  Copy
-                </button>
-                {copiedKey === `session-${s.id}` && <span className={styles.copied}>Copied!</span>}
-              </td>
-              <td>{s.name}</td>
-            </tr>
-          ))}
-          </tbody>
-        </table>
-      </section>
 
       <section className={styles.section}>
         <h3>Create Player Account</h3>
@@ -149,42 +80,58 @@ const Admin: React.FC = () => {
         {createdUsers.length > 0 && (
           <table className={styles.table}>
             <thead>
-            <tr>
-              <th>Username</th>
-              <th>Access Code</th>
-              <th>Expires</th>
-            </tr>
+              <tr>
+                <th>Username</th>
+                <th>Access Code</th>
+                <th>Expires</th>
+              </tr>
             </thead>
             <tbody>
-            {createdUsers.map((u, idx) => (
-              <tr key={u.username}>
-                <td>
-                  {u.username}
-                  <button
-                    className={styles.copyButton}
-                    onClick={() => handleCopy(u.username, `user-${idx}-name`)}
-                  >
-                    Copy
-                  </button>
-                  {copiedKey === `user-${idx}-name` && (
-                    <span className={styles.copied}>Copied!</span>
-                  )}
-                </td>
-                <td>
-                  {u.accessCode}
-                  <button
-                    className={styles.copyButton}
-                    onClick={() => handleCopy(u.accessCode, `user-${idx}-code`)}
-                  >
-                    Copy
-                  </button>
-                  {copiedKey === `user-${idx}-code` && (
-                    <span className={styles.copied}>Copied!</span>
-                  )}
-                </td>
-                <td>{new Date(u.expirationDate).toLocaleString()}</td>
-              </tr>
-            ))}
+              {createdUsers.map((u, idx) => {
+                const exp = new Date(u.expirationDate);
+                const expired = exp.getTime() < Date.now();
+                const expString = exp.toLocaleString();
+                return (
+                  <tr key={u.username}>
+                    <td>
+                      {u.username}
+                      <button
+                        className={styles.copyButton}
+                        onClick={() => handleCopy(u.username, `user-${idx}-name`)}
+                      >
+                        Copy
+                      </button>
+                      {copiedKey === `user-${idx}-name` && (
+                        <span className={styles.copied}>Copied!</span>
+                      )}
+                    </td>
+                    <td>
+                      {u.accessCode}
+                      <button
+                        className={styles.copyButton}
+                        onClick={() => handleCopy(u.accessCode, `user-${idx}-code`)}
+                      >
+                        Copy
+                      </button>
+                      {copiedKey === `user-${idx}-code` && (
+                        <span className={styles.copied}>Copied!</span>
+                      )}
+                    </td>
+                    <td className={expired ? styles.expired : undefined}>
+                      {expString}
+                      <button
+                        className={styles.copyButton}
+                        onClick={() => handleCopy(expString, `user-${idx}-exp`)}
+                      >
+                        Copy
+                      </button>
+                      {copiedKey === `user-${idx}-exp` && (
+                        <span className={styles.copied}>Copied!</span>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
             </tbody>
           </table>
         )}

--- a/client/src/pages/admin/admin.module.css
+++ b/client/src/pages/admin/admin.module.css
@@ -26,30 +26,31 @@
     margin-bottom: 1rem;
 }
 
+/* Tables */
+.table {
+    width: 100%;
+    margin-top: 1rem;
+    border-collapse: collapse;
+}
 
-    /* Tables */
+.table th,
+.table td {
+    border: 1px solid #ccc;
+    padding: 0.5rem;
+}
 
-    .table {
-        width: 100%;
-        margin-top: 1rem;
-        border-collapse: collapse;
-    }
+/* Copy button */
+.copyButton {
+    margin-left: 0.5rem;
+    padding: 0.2rem 0.5rem;
+}
 
-    .table th,
-    .table td {
-        border: 1px solid #ccc;
-        padding: 0.5rem;
-    }
+.copied {
+    margin-left: 0.5rem;
+    color: #0a0;
+    font-size: 0.8rem;
+}
 
-    /* Copy button */
-
-    .copyButton {
-        margin-left: 0.5rem;
-        padding: 0.2rem 0.5rem;
-    }
-
-    .copied {
-        margin-left: 0.5rem;
-        color: #0a0;
-        font-size: 0.8rem;
-    }
+.expired {
+    background: #fdd;
+}


### PR DESCRIPTION
## Summary
- remove session controller, entity, repository, service and migration from backend
- simplify admin panel to only create player accounts, persisting them locally with copy buttons and expiry highlighting

## Testing
- `npm run lint` *(fails: 15 errors, 6 warnings)*
- `npm run build` *(fails: useEffect is declared but its value is never read)*
- `mvn test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_689b2e39c6d8832787c66bb749925121