### PR TITLE
Record admin creator for users and list owned users

### DIFF
--- a/backend/src/main/java/org/example/backend/controllers/UsersController.java
+++ b/backend/src/main/java/org/example/backend/controllers/UsersController.java
@@ -11,11 +11,13 @@ import org.example.backend.services.UsersService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.Duration;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
 
@@ -80,17 +82,32 @@ public class UsersController {
     @PostMapping("/random")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     public ResponseEntity<?> createRandomEphemeralUser(
-            @RequestParam(name = "validityMinutes", required = false, defaultValue = "60") long validityMinutes
+            @RequestParam(name = "validityMinutes", required = false, defaultValue = "60") long validityMinutes,
+            Authentication authentication
     ) {
         if (validityMinutes <= 0) {
             return ResponseEntity.badRequest().body(Map.of("error", "validityMinutes must be > 0"));
         }
-        UsersService.CreatedUser created = service.createRandomUser(Duration.ofMinutes(validityMinutes));
+        UsersService.CreatedUser created = service.createRandomUser(Duration.ofMinutes(validityMinutes), authentication.getName());
         return ResponseEntity.ok(Map.of(
                 "username", created.getUsername(),
                 "accessCode", created.getAccessCode(),
                 "expirationDate", created.getExpirationDate()
         ));
+    }
+
+    @GetMapping("/created")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    public ResponseEntity<?> getUsersCreatedByMe(Authentication authentication) {
+        String adminUsername = authentication.getName();
+        List<User> users = service.findUsersCreatedBy(adminUsername);
+        List<Map<String, Object>> data = users.stream()
+                .map(u -> Map.of(
+                        "username", u.getUsername(),
+                        "expirationDate", u.getExpirationDate()
+                ))
+                .toList();
+        return ResponseEntity.ok(data);
     }
 
     /**

--- a/backend/src/main/java/org/example/backend/controllers/UsersController.java
+++ b/backend/src/main/java/org/example/backend/controllers/UsersController.java
@@ -102,10 +102,12 @@ public class UsersController {
         String adminUsername = authentication.getName();
         List<User> users = service.findUsersCreatedBy(adminUsername);
         List<Map<String, Object>> data = users.stream()
-                .map(u -> Map.of(
-                        "username", u.getUsername(),
-                        "expirationDate", u.getExpirationDate()
-                ))
+                .map(u -> {
+                    Map<String, Object> m = new HashMap<>();
+                    m.put("username", u.getUsername());
+                    m.put("expirationDate", u.getExpirationDate());
+                    return m;
+                })
                 .toList();
         return ResponseEntity.ok(data);
     }

--- a/backend/src/main/java/org/example/backend/model/User.java
+++ b/backend/src/main/java/org/example/backend/model/User.java
@@ -27,6 +27,9 @@ public class User {
     @Column(name = "role", nullable = false, length = 40)
     private String role; // e.g. ROLE_ADMIN / ROLE_USER
 
+    @Column(name = "created_by", length = 120)
+    private String createdBy; // admin username that created this user
+
     /* Ephemeral access code support */
     @Column(name = "expiration_date")
     private Instant expirationDate;

--- a/backend/src/main/java/org/example/backend/repos/UserRepository.java
+++ b/backend/src/main/java/org/example/backend/repos/UserRepository.java
@@ -17,4 +17,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     @Query("select u from User u where (u.expirationDate is null or u.expirationDate > :now)")
     List<User> findAllActive(@Param("now") Instant now);
+
+    List<User> findAllByCreatedBy(String createdBy);
 }

--- a/backend/src/main/java/org/example/backend/services/UsersService.java
+++ b/backend/src/main/java/org/example/backend/services/UsersService.java
@@ -14,6 +14,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.List;
 import java.util.Objects;
 
 @Slf4j
@@ -47,21 +48,25 @@ public class UsersService {
         userRepository.deleteById(id);
     }
 
+    public List<User> findUsersCreatedBy(String createdBy) {
+        return userRepository.findAllByCreatedBy(createdBy);
+    }
+
     /* ---------------- Random / Ephemeral Users ---------------- */
 
     private static final String ACCESS_CODE_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
     private static final int ACCESS_CODE_LENGTH = 6;
     private static final SecureRandom RNG = new SecureRandom();
 
-    public CreatedUser createRandomUser(Duration validity) {
+    public CreatedUser createRandomUser(Duration validity, String createdBy) {
         Objects.requireNonNull(validity, "validity");
         if (validity.isZero() || validity.isNegative()) {
             throw new IllegalArgumentException("validity must be positive");
         }
-        return createRandomUser(Instant.now().plus(validity));
+        return createRandomUser(Instant.now().plus(validity), createdBy);
     }
 
-    public CreatedUser createRandomUser(Instant expirationDate) {
+    public CreatedUser createRandomUser(Instant expirationDate, String createdBy) {
         Objects.requireNonNull(expirationDate, "expirationDate");
         if (expirationDate.isBefore(Instant.now())) {
             throw new IllegalArgumentException("expirationDate must be in the future");
@@ -77,6 +82,7 @@ public class UsersService {
         u.setAccessCodeSha256(sha256Hex(accessCode));                // Deterministic index
         u.setRole("ROLE_USER");
         u.setExpirationDate(expirationDate);
+        u.setCreatedBy(createdBy);
         // email must be set if not nullable; if ephemeral, generate a placeholder:
         u.setEmail(username + "@temp.local");
 

--- a/backend/src/main/resources/db/migration/V1755012610491__userCreatedBy.sql
+++ b/backend/src/main/resources/db/migration/V1755012610491__userCreatedBy.sql
@@ -1,0 +1,1 @@
+ALTER TABLE app_user ADD COLUMN created_by VARCHAR(120);

--- a/client/src/pages/admin/Admin.tsx
+++ b/client/src/pages/admin/Admin.tsx
@@ -7,7 +7,7 @@ interface Session {
 
 interface CreatedUser {
   username: string;
-  accessCode: string;
+  accessCode?: string;
   expirationDate: string;
 }
 
@@ -39,9 +39,29 @@ const Admin: React.FC = () => {
     }
   }, [token]);
 
+  const fetchCreatedUsers = useCallback(async () => {
+    try {
+      const res = await fetch(
+        `${import.meta.env.VITE_BACKEND}/api/v1/users/created`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        }
+      );
+      if (res.ok) {
+        const data = await res.json();
+        setCreatedUsers(data);
+      }
+    } catch (err) {
+      console.error('Failed to load created users', err);
+    }
+  }, [token]);
+
   useEffect(() => {
     fetchSessions();
-  }, [fetchSessions]);
+    fetchCreatedUsers();
+  }, [fetchSessions, fetchCreatedUsers]);
 
   const handleCopy = async (value: string, key: string) => {
     try {
@@ -183,17 +203,21 @@ const Admin: React.FC = () => {
                     )}
                   </td>
                   <td>
-                    {u.accessCode}
-                    <button
-                      className={styles.copyButton}
-                      onClick={() =>
-                        handleCopy(u.accessCode, `user-${idx}-code`)
-                      }
-                    >
-                      Copy
-                    </button>
-                    {copiedKey === `user-${idx}-code` && (
-                      <span className={styles.copied}>Copied!</span>
+                    {u.accessCode ?? 'N/A'}
+                    {u.accessCode && (
+                      <>
+                        <button
+                          className={styles.copyButton}
+                          onClick={() =>
+                            handleCopy(u.accessCode!, `user-${idx}-code`)
+                          }
+                        >
+                          Copy
+                        </button>
+                        {copiedKey === `user-${idx}-code` && (
+                          <span className={styles.copied}>Copied!</span>
+                        )}
+                      </>
                     )}
                   </td>
                   <td>{new Date(u.expirationDate).toLocaleString()}</td>


### PR DESCRIPTION
## Summary
- store the creating admin's username for each user
- expose an API to list users created by the current admin and use it in the admin UI

## Testing
- `mvn -q -f backend/pom.xml test` *(fails: Non-resolvable parent POM: Network is unreachable)*
- `yarn lint` *(fails: Error when performing the request to https://registry.yarnpkg.com/yarn/-/yarn-1.22.22.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68b0696d66a08327895531f59bcde3c6